### PR TITLE
Updated dependencies to use Webpack 5

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -62,6 +62,7 @@ const common = {
       filename: '[name].css',
     }),
   ],
+  target: ['web', 'es2020'],
 };
 
 module.exports = common;

--- a/index.js
+++ b/index.js
@@ -111,14 +111,14 @@ function createExtension(name, { overridePage, devtools }, dirPath, outputFunc=c
 
   // Add devDependencies
   args.push(
-    'webpack@^4.0.0',
-    'webpack-cli@^3.0.0',
-    'webpack-merge@^5.0.0',
-    'copy-webpack-plugin@^6.0.0',
-    'size-plugin@^2.0.0',
-    'mini-css-extract-plugin@^0.10.0',
-    'css-loader@^4.0.0',
-    'file-loader@^6.0.0'
+    'webpack@^5.65.0',
+    'webpack-cli@^4.9.1',
+    'webpack-merge@^5.8.0',
+    'copy-webpack-plugin@^6.4.1',
+    'size-plugin@^2.0.2',
+    'mini-css-extract-plugin@^0.10.1',
+    'css-loader@^6.5.1',
+    'file-loader@^6.2.0'
   );
 
   outputFunc('Installing packages. This might take a couple of minutes.');


### PR DESCRIPTION
At the beginning, I was simply trying to configure Webpack so that it recognizes javascript ES2021 syntax.
That was possible either by using Babel, or natively with Webpack 5 (which will really improve performances: given the fact that most browsers supports new syntaxes, most polyfills are useless)